### PR TITLE
Add Next.js starter with interactive React Three Fiber 3D portfolio scene

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals", "next/typescript"]
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,169 @@
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  background: #0f1727;
+  color: #e9f0ff;
+  font-family: Inter, system-ui, sans-serif;
+}
+
+.desktop-scene {
+  min-height: 100vh;
+}
+
+.scene-shell {
+  height: 100vh;
+  position: relative;
+}
+
+.scene-shell canvas {
+  display: block;
+}
+
+.hud {
+  pointer-events: none;
+  position: absolute;
+  inset: 0;
+}
+
+.title {
+  position: absolute;
+  top: 1rem;
+  left: 1rem;
+  margin: 0;
+  font-weight: 700;
+}
+
+.subtitle {
+  position: absolute;
+  top: 2.8rem;
+  left: 1rem;
+  margin: 0;
+  color: #d4def8;
+  font-size: 0.9rem;
+}
+
+.crosshair {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 18px;
+  height: 18px;
+  transform: translate(-50%, -50%);
+}
+
+.crosshair::before,
+.crosshair::after {
+  content: "";
+  position: absolute;
+  background: rgba(255, 255, 255, 0.85);
+}
+
+.crosshair::before {
+  width: 2px;
+  height: 18px;
+  left: 8px;
+}
+
+.crosshair::after {
+  width: 18px;
+  height: 2px;
+  top: 8px;
+}
+
+.tooltip {
+  position: absolute;
+  left: 50%;
+  top: calc(50% + 22px);
+  transform: translateX(-50%);
+  background: rgba(16, 24, 39, 0.8);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 0.6rem;
+  padding: 0.4rem 0.65rem;
+  font-size: 0.82rem;
+}
+
+.quick-links {
+  pointer-events: auto;
+  position: absolute;
+  right: 1rem;
+  top: 1rem;
+  display: flex;
+  gap: 0.7rem;
+}
+
+.quick-links a,
+.panel .cta,
+.panel button {
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  color: #f2f7ff;
+  text-decoration: none;
+  padding: 0.45rem 0.75rem;
+  border-radius: 0.55rem;
+  background: rgba(12, 20, 34, 0.75);
+  font-size: 0.86rem;
+}
+
+.panel {
+  position: absolute;
+  right: 1rem;
+  bottom: 1rem;
+  width: min(360px, calc(100% - 2rem));
+  background: rgba(10, 16, 30, 0.93);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 0.8rem;
+  padding: 1rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.panel h2,
+.panel p {
+  margin: 0;
+}
+
+.panel button {
+  width: fit-content;
+  cursor: pointer;
+}
+
+.fallback {
+  padding: 3rem 1rem 4rem;
+  max-width: 1050px;
+  margin: 0 auto;
+}
+
+.fallback h1 {
+  margin-top: 0;
+}
+
+.fallback-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 0.8rem;
+}
+
+.fallback-grid article {
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 0.8rem;
+  padding: 1rem;
+  background: rgba(255, 255, 255, 0.06);
+}
+
+@media (max-width: 900px) {
+  .desktop-scene {
+    min-height: 55vh;
+  }
+
+  .scene-shell {
+    height: 55vh;
+  }
+
+  .subtitle {
+    max-width: 38ch;
+  }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+import "./globals.css";
+
+export const metadata: Metadata = {
+  title: "Jesse's World | Explorable Portfolio",
+  description: "Minecraft-inspired 3D portfolio starter built with Next.js and React Three Fiber.",
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,36 @@
+import GameScene from "@/components/scene/GameScene";
+
+export default function HomePage() {
+  return (
+    <main>
+      <section className="desktop-scene" aria-label="Interactive 3D portfolio world">
+        <GameScene />
+      </section>
+
+      <section id="fallback" className="fallback">
+        <h1>Portfolio fallback</h1>
+        <p>
+          Prefer a traditional site flow? Use this lightweight version with direct links to content sections.
+        </p>
+        <div className="fallback-grid">
+          <article>
+            <h2>Resume</h2>
+            <p>Experience summary, achievements, and downloadable resume links.</p>
+          </article>
+          <article>
+            <h2>Projects</h2>
+            <p>Case studies with architecture notes, outcomes, and implementation details.</p>
+          </article>
+          <article>
+            <h2>Research</h2>
+            <p>Experiments around AI, 3D interaction, and product discovery workflows.</p>
+          </article>
+          <article>
+            <h2>Contact</h2>
+            <p>hello@example.com • LinkedIn • GitHub</p>
+          </article>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/components/scene/GameScene.tsx
+++ b/components/scene/GameScene.tsx
@@ -1,0 +1,218 @@
+"use client";
+
+import { PointerLockControls } from "@react-three/drei";
+import { Canvas, ThreeEvent, useFrame, useThree } from "@react-three/fiber";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import * as THREE from "three";
+import { interactionContent, type InteractionId } from "@/data/interactions";
+
+type Block = {
+  id: InteractionId;
+  position: [number, number, number];
+  color: string;
+  label: string;
+};
+
+const blocks: Block[] = [
+  { id: "resume", position: [0, 0.5, -8], color: "#70d6ff", label: "Open Resume" },
+  { id: "projects", position: [3, 0.5, -12], color: "#c8ff70", label: "View Projects" },
+  { id: "research", position: [-4, 0.5, -11], color: "#ffb570", label: "Enter Research Lab" },
+  { id: "contact", position: [0, 0.5, -16], color: "#d58eff", label: "Contact Portal" },
+];
+
+const obstacleCells = new Set(blocks.map((block) => `${Math.round(block.position[0])}:${Math.round(block.position[2])}`));
+
+function Ground() {
+  const tiles = useMemo(() => {
+    const tileData: [number, number, number][] = [];
+    for (let x = -20; x <= 20; x += 1) {
+      for (let z = -22; z <= 8; z += 1) {
+        tileData.push([x, 0, z]);
+      }
+    }
+    return tileData;
+  }, []);
+
+  return (
+    <group>
+      {tiles.map((tile) => (
+        <mesh key={`${tile[0]}-${tile[2]}`} position={tile} receiveShadow>
+          <boxGeometry args={[1, 0.1, 1]} />
+          <meshStandardMaterial color={tile[2] % 2 === 0 ? "#4e8a50" : "#5d9f60"} />
+        </mesh>
+      ))}
+    </group>
+  );
+}
+
+function PlayerController({ enabled }: { enabled: boolean }) {
+  const { camera } = useThree();
+  const keysRef = useRef<Record<string, boolean>>({});
+
+  useEffect(() => {
+    camera.position.set(0, 1.6, 3);
+  }, [camera]);
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      keysRef.current[event.code] = true;
+    };
+    const onKeyUp = (event: KeyboardEvent) => {
+      keysRef.current[event.code] = false;
+    };
+
+    window.addEventListener("keydown", onKeyDown);
+    window.addEventListener("keyup", onKeyUp);
+    return () => {
+      window.removeEventListener("keydown", onKeyDown);
+      window.removeEventListener("keyup", onKeyUp);
+    };
+  }, []);
+
+  useFrame((_state, delta) => {
+    if (!enabled) return;
+    const speed = 4.25;
+    const forward = new THREE.Vector3();
+    camera.getWorldDirection(forward);
+    forward.y = 0;
+    forward.normalize();
+
+    const right = new THREE.Vector3(forward.z, 0, -forward.x).normalize();
+    const movement = new THREE.Vector3();
+
+    if (keysRef.current.KeyW) movement.add(forward);
+    if (keysRef.current.KeyS) movement.sub(forward);
+    if (keysRef.current.KeyA) movement.sub(right);
+    if (keysRef.current.KeyD) movement.add(right);
+
+    if (movement.lengthSq() === 0) return;
+    movement.normalize().multiplyScalar(speed * delta);
+
+    const candidate = camera.position.clone().add(movement);
+    const cellX = Math.round(candidate.x);
+    const cellZ = Math.round(candidate.z);
+    const blocked = obstacleCells.has(`${cellX}:${cellZ}`);
+
+    const insideBounds = candidate.x > -19 && candidate.x < 19 && candidate.z > -21 && candidate.z < 7;
+    if (!blocked && insideBounds) {
+      camera.position.set(candidate.x, 1.6, candidate.z);
+    }
+  });
+
+  return null;
+}
+
+function InteractionRaycast({ onTarget }: { onTarget: (id: InteractionId | null, label: string | null) => void }) {
+  const { camera, scene } = useThree();
+  const raycaster = useMemo(() => new THREE.Raycaster(), []);
+
+  useFrame(() => {
+    raycaster.setFromCamera(new THREE.Vector2(0, 0), camera);
+    const hits = raycaster.intersectObjects(scene.children, true);
+    const hit = hits.find((entry) => (entry.object.userData?.interactionId as InteractionId | undefined));
+
+    if (!hit) {
+      onTarget(null, null);
+      return;
+    }
+
+    onTarget(hit.object.userData.interactionId as InteractionId, hit.object.userData.label as string);
+  });
+
+  return null;
+}
+
+function InteractableBlock({ block }: { block: Block }) {
+  return (
+    <mesh
+      position={block.position}
+      castShadow
+      userData={{ interactionId: block.id, label: block.label }}
+      onClick={(event: ThreeEvent<MouseEvent>) => {
+        event.stopPropagation();
+      }}
+    >
+      <boxGeometry args={[1, 1, 1]} />
+      <meshStandardMaterial color={block.color} />
+    </mesh>
+  );
+}
+
+export default function GameScene() {
+  const [target, setTarget] = useState<InteractionId | null>(null);
+  const [targetLabel, setTargetLabel] = useState<string | null>(null);
+  const [activePanel, setActivePanel] = useState<InteractionId | null>(null);
+  const [locked, setLocked] = useState(false);
+
+  const onTarget = useCallback((id: InteractionId | null, label: string | null) => {
+    setTarget(id);
+    setTargetLabel(label);
+  }, []);
+
+  useEffect(() => {
+    const handleClick = () => {
+      if (!locked || !target) return;
+      setActivePanel(target);
+    };
+
+    window.addEventListener("click", handleClick);
+    return () => window.removeEventListener("click", handleClick);
+  }, [locked, target]);
+
+  const content = activePanel ? interactionContent[activePanel] : null;
+
+  return (
+    <div className="scene-shell">
+      <Canvas camera={{ fov: 70 }} shadows>
+        <color attach="background" args={["#87a9ff"]} />
+        <fog attach="fog" args={["#87a9ff", 12, 40]} />
+        <ambientLight intensity={0.8} />
+        <directionalLight intensity={1.1} position={[6, 10, 6]} castShadow />
+
+        <Ground />
+        {blocks.map((block) => (
+          <InteractableBlock key={block.id} block={block} />
+        ))}
+
+        <PlayerController enabled={locked} />
+        <InteractionRaycast onTarget={onTarget} />
+        <PointerLockControls
+          onLock={() => setLocked(true)}
+          onUnlock={() => {
+            setLocked(false);
+            setTarget(null);
+            setTargetLabel(null);
+          }}
+        />
+      </Canvas>
+
+      <div className="hud">
+        <p className="title">Jesse&apos;s World</p>
+        <p className="subtitle">Click anywhere to enter. Move with WASD. Press ESC to unlock.</p>
+        <div className="crosshair" aria-hidden="true" />
+
+        {targetLabel && locked ? <div className="tooltip">{targetLabel}</div> : null}
+
+        <div className="quick-links">
+          <a href="#fallback">Skip 3D / Open standard site</a>
+          <a href="mailto:hello@example.com">Contact</a>
+        </div>
+      </div>
+
+      {content ? (
+        <aside className="panel" role="dialog" aria-label={content.title}>
+          <h2>{content.title}</h2>
+          <p>{content.body}</p>
+          {content.cta ? (
+            <a className="cta" href={content.cta.href}>
+              {content.cta.label}
+            </a>
+          ) : null}
+          <button type="button" onClick={() => setActivePanel(null)}>
+            Close
+          </button>
+        </aside>
+      ) : null}
+    </div>
+  );
+}

--- a/data/interactions.ts
+++ b/data/interactions.ts
@@ -1,0 +1,26 @@
+export type InteractionId = "resume" | "projects" | "research" | "contact";
+
+export const interactionContent: Record<
+  InteractionId,
+  { title: string; body: string; cta?: { href: string; label: string } }
+> = {
+  resume: {
+    title: "Resume House",
+    body: "Download a resume PDF, review career highlights, and get a quick snapshot of experience.",
+    cta: { href: "#", label: "Resume (coming soon)" },
+  },
+  projects: {
+    title: "Projects Room",
+    body: "Walk through flagship projects with architecture, outcomes, and live demos.",
+    cta: { href: "#", label: "Open project archive" },
+  },
+  research: {
+    title: "Research Lab",
+    body: "Explore experiments around AI systems, interaction design, and 3D workflows.",
+  },
+  contact: {
+    title: "Contact Portal",
+    body: "Start a conversation about collaborations, product consulting, or creative engineering.",
+    cta: { href: "mailto:hello@example.com", label: "hello@example.com" },
+  },
+};

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "personal_site",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "@react-three/drei": "^9.122.0",
+    "@react-three/fiber": "^8.17.14",
+    "next": "14.2.18",
+    "react": "18.3.1",
+    "react-dom": "18.3.1",
+    "three": "^0.171.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.2",
+    "@types/react": "^18.3.12",
+    "@types/react-dom": "^18.3.1",
+    "eslint": "^8.57.1",
+    "eslint-config-next": "14.2.18",
+    "typescript": "^5.7.2"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": { "@/*": ["./*"] }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
### Motivation
- Introduce an explorable, Minecraft-inspired 3D portfolio built on Next.js and React Three Fiber to provide a playful interactive landing experience.

### Description
- Add Next.js app scaffold including `app/layout.tsx`, `app/page.tsx`, global styles in `app/globals.css`, and `next.config.mjs` to bootstrap the site layout and styling.
- Implement the interactive world in `components/scene/GameScene.tsx` with a `PlayerController`, pointer-lock controls, raycast-based interaction detection, ground tiles, and clickable `InteractableBlock` entities that open content panels.
- Add structured interaction data in `data/interactions.ts` and TypeScript support via `tsconfig.json` and `next-env.d.ts`.
- Add project metadata and dependencies in `package.json` and a basic ESLint config in `.eslintrc.json`.

### Testing
- No automated tests were executed as part of this change; development scripts added include `dev`, `build`, `start`, and `lint` in `package.json` for local verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4b270d7288324ad3fc51f024e05ec)